### PR TITLE
Switch from PDLA to PDL

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+        - switch from PDLA to PDL
 
 0.003     2016-04-25
         - provide raw text (what once used to be just verbose output)

--- a/lib/BenchmarkAnything/Evaluations.pm
+++ b/lib/BenchmarkAnything/Evaluations.pm
@@ -1,12 +1,12 @@
-use 5.010; # Perl 5.10+ needed for PDL/PDLA
+use 5.010; # Perl 5.10+ needed for PDL
 use strict;
 use warnings;
 package BenchmarkAnything::Evaluations;
 # ABSTRACT: Evaluation support for BenchmarkAnything data
 
-use PDLA::Core;
-use PDLA::Stats;
-use PDLA::Ufunc;
+use PDL::Core;
+use PDL::Stats;
+use PDL::Ufunc;
 
 =head2 multi_point_stats (\@values)
 


### PR DESCRIPTION
As maintainer of both PDL (last released Aug 2021 with many features and bug-fixes since 2019) and PDLA (last released 2019), I can't in good conscience recommend people continue to use PDLA (which should be considered an experiment that has succeeded).

Therefore, this PR, which should not cause any impact given the now greatly-reduced mandatory dependencies in PDL. If/when PDL itself gets split into parts in a similar style to PDLA, this distro would still work, and benefit, because its deps are correct (even if PDL::Core and PDL::Ufunc are likely to end up in separate distros).